### PR TITLE
Updating gem and vimrc template to prevent changes on each run

### DIFF
--- a/files/vimrc
+++ b/files/vimrc
@@ -5,3 +5,4 @@ let g:syntastic_puppet_checkers=['puppet', 'puppetlint']
 set listchars=trail:.
 set list
 set ruler
+let g:syntastic_puppet_puppetlint_args='--no-documentation-check --no-80chars-check --no-autoloader_layout-check'

--- a/manifests/bundle.pp
+++ b/manifests/bundle.pp
@@ -13,7 +13,7 @@ class puppet_vim_env::bundle ( $homedir ) {
   }
 
   if $is_pe_fact == true {
-    $gem_provider = 'pe_gem'
+    $gem_provider = 'puppet_gem'
     $lint_target  = '/opt/puppet/bin/puppet-lint'
   }
   else {


### PR DESCRIPTION
Updated gem from pe_gem to puppet_gem to reflect new 4.0 changes. Also defaulted the templated vimrc file to include the pathogen options as these were causing changes on each puppet run.
