### PR TITLE
stop this fact erroring on Windows

### DIFF
--- a/lib/facter/homedir.rb
+++ b/lib/facter/homedir.rb
@@ -3,6 +3,7 @@
 require 'etc'
 
 Facter.add(:homedir) do
+  confine :kernel => 'Linux'
   setcode do
     user = `whoami`
     Etc.getpwnam(user.chomp).dir


### PR DESCRIPTION
I was getting this error "Could not retrieve homedir: undefined method 'dir' for nil:NilClass"

Which I note from PE-2811 has occurred before.

By limiting this fact to Linux it removes the error. This could be expanded to support OSX/Solaris/AIX but that requires a little more testing.
